### PR TITLE
Tiny fix for colored text on Win32

### DIFF
--- a/clint/textui/colored.py
+++ b/clint/textui/colored.py
@@ -27,6 +27,8 @@ DISABLE_COLOR = False
 
 if not sys.stdout.isatty():
     DISABLE_COLOR = True
+else:
+    colorama.init(autoreset=True)
 
 
 class ColoredString(object):


### PR DESCRIPTION
There's a minor bug on Win32 when printing colored text wtih the `clint.textui` functions: they don't print in color. Specifically, the ANSI codes don't get translated to Win32 equivalents, when using `puts`, for example:

```
~/src/clint[develop]
$ python
Python 2.7.2 (default, Jun 12 2011, 15:08:59) [MSC v.1500 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from clint.textui import puts, colored
>>> puts(colored.red("red?"))
←[31mred?←[39m
>>> puts(colored.red("red?"))
←[31mred?←[39m
>>> print colored.red("red?")
red? # yep, this is actual red text
>>> # it turns out that this is caused by `puts` using the raw sys.stdout
... # instead of the version wrapped by colorama
...
>>> import sys
>>> import clint.textui.core
>>> clint.textui.core.STDOUT # used by `puts`, etc.
<built-in method write of file object at 0x00A75078> # not wrapped properly
>>> sys.stdout.write
<bound method StreamWrapper.write of <clint.packages.colorama.ansitowin32.StreamWrapper object at 0x00DDBD50>>
>>>
```

This fix for `clint.textui.colored` calls `colorama.init(autoreset=True)` at import time, instead of when calling `ColoredString.color_str` (as in the `master` branch, recently removed). That way, the `sys.stdout.write` that gets pulled into `clint.textui.core` is bound to the wrapped version, rather than the original file object:

```
~/src/clint[feature/fix-streamwrap]
$ python
Python 2.7.2 (default, Jun 12 2011, 15:08:59) [MSC v.1500 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from clint.textui import puts, colored
>>> puts(colored.red("is this red?"))
is this red? # why yes, yes it is.
>>> # Since sys.stdout has been wrapped by colorama before getting used
...
>>> import sys
>>> import clint.textui.core
>>> clint.textui.core.STDOUT
<bound method StreamWrapper.write of <clint.packages.colorama.ansitowin32.StreamWrapper object at 0x00D9BA70>>
>>>
```

This only works because `clint.textui.__init__` imports `colored` before everything in `core`, otherwise it might be necessary to structure `puts` to grab stdout at call-time like:

```
def puts(s='', newline=True, stream=None):
    """Prints given string to stdout via Writer interface."""
    if stream is None:
        stream = sys.stdout.write
    Writer()(s, newline, stream=stream)
```

Thanks for the great library! I think using `clint` will really improve codability and usability on a few of my upcoming projects.
