### PR TITLE
Make the width argument take into account the entire BAR_TEMPLATE, not j...

### DIFF
--- a/clint/textui/progress.py
+++ b/clint/textui/progress.py
@@ -24,10 +24,11 @@ def bar(it, label='', width=32, hide=False, empty_char=BAR_EMPTY_CHAR, filled_ch
     """Progress iterator. Wrap your iterables with it."""
 
     def _show(_i):
-        x = int(width*_i/count)
+        progress_width = width - len(label) - len(str(_i)) - len(str(count)) - 4   # '[]' and other chars
+        x = int(progress_width*_i/count)
         if not hide:
             STREAM.write(BAR_TEMPLATE % (
-                label, filled_char*x, empty_char*(width-x), _i, count))
+                label, filled_char*x, empty_char*(progress_width-x), _i, count))
             STREAM.flush()
 
     count = len(it)


### PR DESCRIPTION
...ust the FILLED / EMPTY chars.

Now it's easy for the bar to fill the width of the console:

> > > import os
> > > console_width = int(os.popen('stty size', 'r').read().split()[1])
> > > for i in progress.bar(range(100), width=console_width):
> > >    sleep(random() \* 0.2)
