### PR TITLE
Explicitly chack for instances of bytes to distinguish between py2 and py3

### DIFF
--- a/clint/textui/colored.py
+++ b/clint/textui/colored.py
@@ -62,7 +62,7 @@ class ColoredString(object):
 
     def __unicode__(self):
         value = self.color_str
-        if isinstance(value, str) and hasattr(value, 'decode'):
+        if isinstance(value, bytes):
             return value.decode('utf8')
         return value
 


### PR DESCRIPTION
I was able to confirm py2.5 is not working in many places and there's no reason to add hacks to possibly support it some day. Feels and looks cleaner to explicitly check for instances of bytes.

See: https://github.com/kennethreitz/clint/commit/3a40b682f44ae34b93c9097fb0bdda5fff8622b1
