### PR TITLE
Initialise colorama for textui on Windows.

### DIFF
--- a/clint/textui/__init__.py
+++ b/clint/textui/__init__.py
@@ -7,7 +7,10 @@ clint.textui
 This module provides the text output helper system.
 
 """
-
+import sys
+if sys.platform.startswith('win'):
+    from ..packages import colorama
+    colorama.init()
 
 from . import colored
 from . import progress


### PR DESCRIPTION
This call is necessary for coloured text to work on Windows (see #39).

I don't have my Windows system handy, so someone should test this.

(Replacement for PR #41)
