### PR TITLE
Fixed a typo on line 73.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ I want to quote my console text (like email). ::
     >>>     puts('pretty cool, eh?')
     
     not indented text
-     >  indented text
+     >  quoted text
      >  pretty cool, eh?
 
 I want to color my console text. ::


### PR DESCRIPTION
The command

> > > ```
> > > puts('quoted text')
> > > ```
> > > 
> > > should output 
> > >  quoted text
> > > not
> > >  indented text
