### PR TITLE
colorama.init() required on Windows, noop elsewhere

### DIFF
--- a/clint/textui/colored.py
+++ b/clint/textui/colored.py
@@ -17,6 +17,7 @@ import sys
 PY3 = sys.version_info[0] >= 3
 
 from ..packages import colorama
+colorama.init()
 
 __all__ = (
     'red', 'green', 'yellow', 'blue',


### PR DESCRIPTION
I tested this change on Windows 7 and it works like a charm. Comment it out, and all you see are raw escape sequences.
