### PR TITLE
Added an expected_size parameter to progress.bar and progress.mill.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Patches and Suggestions
 - Alejandro Gómez <alejandrogomez>
 - Jason Piper <jpiper>
 - Gianluca Brindisi <gbrindisi>
+- Don Spaulding <donspauldingii@gmail.com>

--- a/clint/textui/progress.py
+++ b/clint/textui/progress.py
@@ -28,7 +28,7 @@ ETA_INTERVAL = 1
 #How many intervals (excluding the current one) to calculate the simple moving average
 ETA_SMA_WINDOW = 9
 
-def bar(it, label='', width=32, hide=False, empty_char=BAR_EMPTY_CHAR, filled_char=BAR_FILLED_CHAR):
+def bar(it, label='', width=32, hide=False, empty_char=BAR_EMPTY_CHAR, filled_char=BAR_FILLED_CHAR, expected_size=None):
     """Progress iterator. Wrap your iterables with it."""
 
     def _show(_i):
@@ -43,7 +43,7 @@ def bar(it, label='', width=32, hide=False, empty_char=BAR_EMPTY_CHAR, filled_ch
             label, filled_char*x, empty_char*(width-x), _i, count, bar.etadisp))
             STREAM.flush()
 
-    count = len(it)
+    count = len(it) if expected_size is None else expected_size
 
     bar.start    = time.time()
     bar.ittimes  = []
@@ -85,7 +85,7 @@ def dots(it, label='', hide=False):
     STREAM.flush()
 
 
-def mill(it, label='', hide=False,): 
+def mill(it, label='', hide=False, expected_size=None):
     """Progress iterator. Prints a mill while iterating over the items."""
 
     def _mill_char(_i):
@@ -100,7 +100,7 @@ def mill(it, label='', hide=False,):
                 label, _mill_char(_i), _i, count))
             STREAM.flush()
 
-    count = len(it)
+    count = len(it) if expected_size is None else expected_size
 
     if count:
         _show(0)

--- a/examples/progressbar.py
+++ b/examples/progressbar.py
@@ -17,6 +17,11 @@ if __name__ == '__main__':
 
     for i in progress.dots(range(100)):
         sleep(random() * 0.2)
-    
+
     for i in progress.mill(range(100)):
+        sleep(random() * 0.2)
+
+    # Override the expected_size, for iterables that don't support len()
+    D = dict(zip(range(100), range(100)))
+    for k, v in progress.bar(D.iteritems(), expected_size=len(D)):
         sleep(random() * 0.2)


### PR DESCRIPTION
Some objects you might want to show progress on while iterating over
do not support calling len().  In these cases you can now pass
`expected_size` in to the progress.bar and progress.mill functions
to avoid the len() call on the iterable.
