### PR TITLE
Only write progress bars to terminal by default

### DIFF
--- a/clint/textui/progress.py
+++ b/clint/textui/progress.py
@@ -15,7 +15,10 @@ import time
 
 STREAM = sys.stderr
 # Only show bar in terminals by default (better for piping, logging etc.)
-HIDE_DEFAULT = False if STREAM.isatty() else True
+try:
+    HIDE_DEFAULT = not STREAM.isatty()
+except AttributeError:  # output does not support isatty()
+    HIDE_DEFAULT = True
 
 BAR_TEMPLATE = '%s[%s%s] %i/%i - %s\r'
 MILL_TEMPLATE = '%s %s %i/%i\r'  


### PR DESCRIPTION
This removes unwanted progress bar output when piping to another command
or file. Progress bars may be explicitly shown in this case with
progess.bar(iterable, hide=False)

Inspired when a tool I use locally in a terminal has progress bars (good), but when run as a cron job the progress bar output fills up log files (bad).
