### PR TITLE
changed import args to import arguments

### DIFF
--- a/clint/__init__.py
+++ b/clint/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     import collections
     collections.OrderedDict = OrderedDict
 
-from args import *
+from arguments import *
 from . import textui
 from . import utils
 from .pipes import piped_in


### PR DESCRIPTION
I was trying to build the docs and noticed this in clint/**init**.py
