### PR TITLE
Add textui streams to __all__

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Patches and Suggestions
 - Gianluca Brindisi <gbrindisi>
 - Don Spaulding <donspauldingii@gmail.com>
 - Justin Barber <barber.justin (at) gmail>
+- Dmitry Medvinsky

--- a/clint/textui/core.py
+++ b/clint/textui/core.py
@@ -21,7 +21,7 @@ from ..utils import tsplit
 
 
 __all__ = ('puts', 'puts_err', 'indent', 'dedent', 'columns', 'max_width',
-    'min_width')
+    'min_width', 'STDOUT', 'STDERR')
 
 
 STDOUT = sys.stdout.write


### PR DESCRIPTION
So that I could write

```
from clint import textui as ui
ui.puts(ui.colored.red('fatal error'), stream=ui.STDERR)
```
