### PR TITLE
Made import of the arguments module relative.

### DIFF
--- a/clint/__init__.py
+++ b/clint/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     import collections
     collections.OrderedDict = OrderedDict
 
-from arguments import *
+from .arguments import *
 from . import textui
 from . import utils
 from .pipes import piped_in


### PR DESCRIPTION
I needed to do this, otherwise I got `ImportError: No module named arguments` when running `test_clint.py` and sphinx' `make html`.
