### PR TITLE
Fix 404 to AUTHORS in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,4 +160,4 @@ Roadmap
 
 
 .. _`the repository`: http://github.com/kennethreitz/clint
-.. _AUTHORS: http://github.com/kennethreitz/clint/blob/master/AUTHORS
+.. _AUTHORS: http://github.com/kennethreitz/clint/blob/develop/AUTHORS


### PR DESCRIPTION
The link to AUTHORS in the README referenced the `master` branch, which doesn't exist. Changed link to reference the `develop` branch.
