### PR TITLE
Use print() function to fix install on python 3

### DIFF
--- a/clint/textui/prompt.py
+++ b/clint/textui/prompt.py
@@ -8,7 +8,7 @@ Module for simple interactive prompts handling
 
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 from re import match, I
 
@@ -30,7 +30,7 @@ def yn(prompt, default='y', batch=False):
         if not batch:
             input = raw_input(prompt).strip()
         else:
-            print prompt
+            print(prompt)
             input = ''
 
         # If input is empty default choice is assumed


### PR DESCRIPTION
clint 0.3.2 can't be installed on python 3.3 because of this print statement.

```
Downloading/unpacking clint
  Running setup.py egg_info for package clint
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/home/simon/lib/virtualenvs/clint/build/clint/setup.py", line 12, in <module>
        import clint
      File "./clint/__init__.py", line 22, in <module>
        from . import textui
      File "./clint/textui/__init__.py", line 17, in <module>
        from . import prompt
      File "./clint/textui/prompt.py", line 33
        print prompt
                   ^
    SyntaxError: invalid syntax
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/home/simon/lib/virtualenvs/clint/build/clint/setup.py", line 12, in <module>

    import clint

  File "./clint/__init__.py", line 22, in <module>

    from . import textui

  File "./clint/textui/__init__.py", line 17, in <module>

    from . import prompt

  File "./clint/textui/prompt.py", line 33

    print prompt

               ^

SyntaxError: invalid syntax

```
