### PR TITLE
fix unicode.py import error

### DIFF
--- a/examples/unicode.py
+++ b/examples/unicode.py
@@ -11,9 +11,11 @@ try:
 except:
     import simplejson as json
 
-from clint import args
+from clint.arguments import Args
 from clint import piped_in
 from clint.textui import colored, puts, indent
+
+args = Args()
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
unicode.sh fails 

Traceback (most recent call last):
  File "unicode.py", line 14, in <module>
    from clint import args
ImportError: cannot import name args
