### PR TITLE
Fix sys.argv import when running inside LLDB Python interpreter.

### DIFF
--- a/clint/arguments.py
+++ b/clint/arguments.py
@@ -12,7 +12,12 @@ This module provides the CLI argument interface.
 from __future__ import absolute_import
 
 import os
-from sys import argv
+try:
+    from sys import argv
+except ImportError:
+    # Can happen when executing inside LLDB context
+    import sys
+    sys.argv = []
 
 try:
     from collections import OrderedDict


### PR DESCRIPTION
I'm using clint.colored inside LLDB scripts, and this fix is required for that to work.
