### PR TITLE
Fixes progress.mill display when every is greater than 1

### DIFF
--- a/clint/textui/progress.py
+++ b/clint/textui/progress.py
@@ -97,7 +97,7 @@ def mill(it, label='', hide=HIDE_DEFAULT, expected_size=None, every=1):
     """Progress iterator. Prints a mill while iterating over the items."""
 
     def _mill_char(_i):
-        if _i == 100:
+        if _i >= count:
             return ' '
         else:
             return MILL_CHARS[(_i / every) % len(MILL_CHARS)]


### PR DESCRIPTION
This fixes a bug where when "every" isn't equal to 1 mod 4, the mill won't update properly. If it's a multiple of 4, the mill wouldn't even move at all. Also fixes a bug where the mill was cleared at a count of 100 rather than after completion.
