### PR TITLE
ColoredString doesn't attempt to decode explicitly given bytes in python 2

### DIFF
--- a/clint/textui/colored.py
+++ b/clint/textui/colored.py
@@ -48,19 +48,19 @@ class ColoredString(object):
         self.bold = bold
 
     def __getattr__(self, att):
-             def func_help(*args, **kwargs):
-                 result = getattr(self.s, att)(*args, **kwargs)
-                 try:
-                     is_result_string = isinstance(result, basestring)
-                 except NameError:
-                     is_result_string = isinstance(result, str)
-                 if is_result_string:
-                      return self._new(result)
-                 elif isinstance(result, list):
-                     return [self._new(x) for x in result]
-                 else:
-                     return result
-             return func_help
+        def func_help(*args, **kwargs):
+            result = getattr(self.s, att)(*args, **kwargs)
+            try:
+                is_result_string = isinstance(result, basestring)
+            except NameError:
+                is_result_string = isinstance(result, str)
+            if is_result_string:
+                return self._new(result)
+            elif isinstance(result, list):
+                return [self._new(x) for x in result]
+            else:
+                return result
+        return func_help
 
     @property
     def color_str(self):
@@ -91,7 +91,10 @@ class ColoredString(object):
         __str__ = __unicode__
     else:
         def __str__(self):
-            return unicode(self).encode('utf8')
+            value = self.color_str
+            if isinstance(value, bytes):
+                return value
+            return value.encode('utf8')
 
     def __iter__(self):
         return iter(self.color_str)

--- a/test_clint.py
+++ b/test_clint.py
@@ -42,5 +42,13 @@ class ColoredStringTestCase(unittest.TestCase):
         output = new_str.replace("world", "universe")
         assert output.s == "hello universe"
 
+    def test_py2_bytes_not_mangled(self):
+        from clint.textui.colored import ColoredString
+        # On python 2 make sure the same bytes come out as went in
+        new_str = ColoredString('RED', '\xe4')
+        assert '\xe4' in str(new_str)
+        from clint.textui import puts
+        puts(new_str)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In python 2, if you made a byte string colored, it was assumed to be utf8 encoded, and needlessly decoded/encoded whenever **str** was called

(I also fixed some indentation)
