### PR TITLE
Fixed bold issue

### DIFF
--- a/clint/textui/colored.py
+++ b/clint/textui/colored.py
@@ -65,7 +65,7 @@ class ColoredString(object):
     @property
     def color_str(self):
         style = 'BRIGHT' if self.bold else 'NORMAL'
-        c = '%s%s%s%s' % (getattr(colorama.Fore, self.color), getattr(colorama.Style, style), self.s, colorama.Fore.RESET)
+        c = '%s%s%s%s%s' % (getattr(colorama.Fore, self.color), getattr(colorama.Style, style), self.s, colorama.Fore.RESET, getattr(colorama.Style, 'NORMAL'))
 
         if self.always_color:
             return c


### PR DESCRIPTION
Bold would get "stuck" on in powershell/cmd prompt.

from clint.textui import colored

print colored.red("This will be normal")
print colored.red("This is bold", bold=True)
print "this will stay bold."

Would reproduce the issue. Seems that bold needs to be cleared after it is used, aka style has to be forced... It's a minor edit, maybe not an ideal fix, but this resolved it for me.
