### PR TITLE
Always dedent when leaving indent context manager.

### DIFF
--- a/clint/textui/core.py
+++ b/clint/textui/core.py
@@ -79,8 +79,10 @@ def dedent():
 @contextmanager
 def _indent_context():
     """Indentation context manager."""
-    yield
-    dedent()
+    try:
+        yield
+    finally:
+        dedent()
 
 def indent(indent=4, quote=''):
     """Indentation manager, return an indentation context manager."""


### PR DESCRIPTION
The indent context manager doesn't play well with exception handling. Raising an exception within a nested block will bypass dedentation. As a toy example in python3:

```
from clint.textui import puts, indent
from contextlib import suppress

puts("Unindented.")
with suppress(TypeError), indent(2):
    puts("Indented.")
    raise TypeError
puts("Still indented :(.")
```
