### PR TITLE
Fix syntax error prevent installation in Python 3.x

### DIFF
--- a/clint/textui/prompt.py
+++ b/clint/textui/prompt.py
@@ -86,5 +86,5 @@ def query(prompt, default='', validators=None, batch=False):
             for validator in validators:
                 user_input = validator(user_input)
             return user_input
-        except Exception, e:
+        except Exception as e:
             puts(yellow(e.message))


### PR DESCRIPTION
An exception handled in textui.prompt was being handled using the old-style
`except Exception, e:` syntax. I've updated this, but specifically have not
addressed the potential issue of catching a bare exception.

Closes #122.
