### PR TITLE
refactor(prompt): Use query system in prompt.yn and add documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Patches and Suggestions
 - Eric Anderson
 - Joshua Richardson
 - Brandon Liu <thenovices>
+- Reto Aebersold

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,6 @@ Current Features:
 Future Features:
 ----------------
 - Documentation!
-- Simple choice system ``Are you sure? [Yn]``
 - Suggestions welcome.
 
 
@@ -117,7 +116,10 @@ I want to ask for input. ::
     >>> from clint.textui import prompt, validators
     >>> path = prompt.query('Installation Path', default='/usr/local/bin/', validators=[validators.PathValidator()])
 
+I want to ask for a choice. ::
 
+    >>> from clint.textui import prompt
+    >>> sure = prompt.yn('Are you sure?')
 Installation
 ------------
 

--- a/clint/textui/prompt.py
+++ b/clint/textui/prompt.py
@@ -10,11 +10,9 @@ Module for simple interactive prompts handling
 
 from __future__ import absolute_import, print_function
 
-from re import match, I
-
 from .core import puts
 from .colored import yellow
-from .validators import RegexValidator
+from .validators import RegexValidator, YnValidator
 
 try:
     raw_input
@@ -28,38 +26,13 @@ def yn(prompt, default='y', batch=False):
     if default not in ['y', 'n']:
         default = 'y'
 
-    # Let's build the prompt
-    choicebox = '[Y/n]' if default == 'y' else '[y/N]'
-    prompt = prompt + ' ' + choicebox + ' '
+    def default_prompt(value):
+        return '[Y/n]' if value == 'y' else '[y/N]'
 
-    # If input is not a yes/no variant or empty
-    # keep asking
-    while True:
-        # If batch option is True then auto reply
-        # with default input
-        if not batch:
-            input = raw_input(prompt).strip()
-        else:
-            print(prompt)
-            input = ''
-
-        # If input is empty default choice is assumed
-        # so we return True
-        if input == '':
-            return True
-
-        # Given 'yes' as input if default choice is y
-        # then return True, False otherwise
-        if match('y(?:es)?', input, I):
-            return True if default == 'y' else False
-
-        # Given 'no' as input if default choice is n
-        # then return True, False otherwise
-        elif match('n(?:o)?', input, I):
-            return True if default == 'n' else False
+    return query(prompt, default=default, validators=[YnValidator()], batch=batch, custom_default_prompt=default_prompt)
 
 
-def query(prompt, default='', validators=None, batch=False):
+def query(prompt, default='', validators=None, batch=False, custom_default_prompt=None):
     # Set the nonempty validator as default
     if validators is None:
         validators = [RegexValidator(r'.+')]
@@ -69,7 +42,10 @@ def query(prompt, default='', validators=None, batch=False):
         prompt += ' '
 
     if default:
-        prompt += '[' + default + '] '
+        if custom_default_prompt:
+            prompt += custom_default_prompt(default)
+        else:
+            prompt += '[' + default + ']'
 
     # If input is not valid keep asking
     while True:
@@ -79,7 +55,7 @@ def query(prompt, default='', validators=None, batch=False):
             user_input = raw_input(prompt).strip() or default
         else:
             print(prompt)
-            user_input = ''
+            user_input = default
 
         # Validate the user input
         try:

--- a/clint/textui/validators.py
+++ b/clint/textui/validators.py
@@ -102,3 +102,15 @@ class IntegerValidator(object):
             return int(value)
         except (TypeError, ValueError):
             raise ValidationError(self.message)
+
+
+class YnValidator(object):
+    def __call__(self, value):
+        """
+        Validates that the input as bool.
+        """
+        if re.match('n(?:o)?', value, re.I):
+            return False
+
+        return True
+

--- a/examples/prompt.py
+++ b/examples/prompt.py
@@ -18,4 +18,8 @@ if __name__ == '__main__':
     # Use a default value and a validator
     path = prompt.query('Installation Path', default='/usr/local/bin/', validators=[validators.PathValidator()])
 
-    puts(colored.blue('Hi {0}. Install {1} to {2}'.format(name, language or 'nothing', path)))
+    # Use y/n choice
+    if prompt.yn("Are you sure?"):
+        puts(colored.blue('Hi {0}. Install {1} to {2}'.format(name, language or 'nothing', path)))
+    else:
+        puts(colored.blue('Bye {0}!').format(name))


### PR DESCRIPTION
The undocumented `prompt.yn` used its own query implementation. Update `prompt.query` to accept a custom default prompt render function and refactor `prompt.yn` to use the default query system using the `YnValidator`.
