### PR TITLE
Fix classifiers not appearing on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     install_requires=required,
     license='ISC',
-    classifiers=(
+    classifiers=[
 #       'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
@@ -51,5 +51,5 @@ setup(
         'Programming Language :: Python :: 3.1',
         'Programming Language :: Python :: 3.2',
         'Topic :: Terminals :: Terminal Emulators/X Terminals',
-    ),
+    ],
 )


### PR DESCRIPTION
The classifiers aren't appearing on PyPI. https://pypi.python.org/pypi/clint/

This usually fixes it.