### PR TITLE
Add format_str parameter for progress bar and mill

### DIFF
--- a/examples/progressbar.py
+++ b/examples/progressbar.py
@@ -14,7 +14,12 @@ from clint.textui import progress
 if __name__ == '__main__':
     for i in progress.bar(range(100)):
         sleep(random() * 0.2)
-        
+
+    for i in progress.bar(
+            range(50), label='custom format',
+            format_str='{label} <{bar}> {total} of {completed}, ETA: {eta}'):
+        sleep(random() * 0.2)
+
     with progress.Bar(label="nonlinear", expected_size=10) as bar:
         last_val = 0
         for val in (1,2,3,9,10):


### PR DESCRIPTION
I wanted to add a way to customise the progress bar output, so implemented a parameter to pass a format string.

The details are in the commit message, but is shown here with formatting:

---

`progress.Bar`, `progress.bar`, and `progress.mill` have a new `format_str` parameter.

Named fields are used to facilitate the change. Using the new syntax, the original formats could be
represented as below:

```python
'{label}[{bar}] {completed}/{total} - {eta}'
'{label} {mill} {completed}/{total}'
```

`str.format()` fails gracefully when named fields aren't present in the string,
allowing a given part of the string to be omitted. On the other hand, incorrect
field names cause a KeyError, preventing user error.

Note that when `format_str=None`, the old templates are used so that any code that
modifies `progress.BAR_TEMPLATE`, for example, is not affected by the change.

Also, the `format_str` parameter does not require `\r` at the end, it is appended
automatically.