### PR TITLE
Support clint.textui.max_width as context manager

### DIFF
--- a/clint/textui/core.py
+++ b/clint/textui/core.py
@@ -15,7 +15,7 @@ import sys
 
 from contextlib import contextmanager
 
-from .formatters import max_width, min_width
+from .formatters import max_width, min_width, _get_max_width_context
 from .cols import columns
 from ..utils import tsplit
 
@@ -53,6 +53,11 @@ def _indent(indent=0, quote='', indent_char=' '):
 
 def puts(s='', newline=True, stream=STDOUT):
     """Prints given string to stdout."""
+    max_width_ctx = _get_max_width_context()
+    if max_width_ctx:
+        cols, separator = max_width_ctx[-1]
+        s = max_width(s, cols, separator)
+
     if newline:
         s = tsplit(s, NEWLINES)
         s = map(str, s)


### PR DESCRIPTION
issue: https://github.com/kennethreitz/clint/issues/2

``` python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

from clint.textui import puts, max_width, indent

with max_width(6):
    puts('Hello world')

with max_width(20):
    puts('Hello world')

with indent(4):
    with max_width(6):
        puts('Hello world')

with max_width(20):
    puts('Hello world')
    with max_width(6):
        puts('Hello world')
    puts('Hello world')
```

to get output::

```
Hello
world
Hello world
    Hello
    world
Hello world
Hello
world
Hello world
```
