### PR TITLE
Fix unicode error python2

### DIFF
--- a/clint/textui/colored.py
+++ b/clint/textui/colored.py
@@ -42,7 +42,10 @@ class ColoredString(object):
     """Enhanced string for __len__ operations on Colored output."""
     def __init__(self, color, s, always_color=False, bold=False):
         super(ColoredString, self).__init__()
-        self.s = s
+        if not PY3 and isinstance(s, unicode):
+            self.s = s.encode('utf-8')
+        else:
+            self.s = s
         self.color = color
         self.always_color = always_color
         self.bold = bold
@@ -93,10 +96,7 @@ class ColoredString(object):
         __str__ = __unicode__
     else:
         def __str__(self):
-            value = self.color_str
-            if isinstance(value, bytes):
-                return value
-            return value.encode('utf8')
+            return self.color_str
 
     def __iter__(self):
         return iter(self.color_str)

--- a/test_clint.py
+++ b/test_clint.py
@@ -18,25 +18,25 @@ class ClintTestCase(unittest.TestCase):
         pass
 
 class ColoredStringTestCase(unittest.TestCase):
-    
+
     def setUp(self):
         from clint.textui.colored import ColoredString
-    
+
     def tearDown(self):
         pass
-    
+
     def test_split(self):
         from clint.textui.colored import ColoredString
         new_str = ColoredString('red', "hello world")
         output = new_str.split()
         assert output[0].s == "hello"
-    
+
     def test_find(self):
         from clint.textui.colored import ColoredString
         new_str = ColoredString('blue', "hello world")
         output = new_str.find('h')
         self.assertEqual(output, 0)
-        
+
     def test_replace(self):
         from clint.textui.colored import ColoredString
         new_str = ColoredString('green', "hello world")
@@ -49,13 +49,18 @@ class ColoredStringTestCase(unittest.TestCase):
         new_str = ColoredString('RED', '\xe4')
         assert '\xe4' in str(new_str)
         from clint.textui import puts
-        puts(new_str)
 
     def test_clint_force_color_env_var(self):
         from clint.textui.colored import ColoredString
         os.environ['CLINT_FORCE_COLOR'] = "1"
         new_str = ColoredString('RED', 'hello world')
         assert new_str.always_color == True
+
+    def test_clint_unicode_radd(self):
+        from clint.textui.colored import ColoredString
+        inp_str = u'hello \u263A'
+        new_str = u'' + ColoredString('RED', inp_str)
+        assert inp_str.encode('utf-8') in new_str
 
 
 class TextuiFormatterTestCase(unittest.TestCase):


### PR DESCRIPTION
Since magic methods `__add__` and `__radd__` call `str` on input string, exception is thrown when input string is unicode with non-ascii characters. This PR fixes issue by properly encoding unicode into string on init.