### PR TITLE
Change "Application" to "Interface" in Readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Clint: Python Command-line Application Tools
+Clint: Python Command-line Interface Tools
 ============================================
 
 **Clint** is a module filled with a set of awesome tools for developing


### PR DESCRIPTION
WIthout this change the title in the readme reads suggests the acronym should be _Clant_, at first glance.
