### PR TITLE
[FIX] fix typing error 'aruments' to 'arguments'

### DIFF
--- a/examples/args.py
+++ b/examples/args.py
@@ -12,7 +12,7 @@ from clint.textui import puts, colored, indent
 args = Args()
 
 with indent(4, quote='>>>'):
-    puts(colored.red('Aruments passed in: ') + str(args.all))
+    puts(colored.red('Arguments passed in: ') + str(args.all))
     puts(colored.red('Flags detected: ') + str(args.flags))
     puts(colored.red('Files detected: ') + str(args.files))
     puts(colored.red('NOT Files detected: ') + str(args.not_files))


### PR DESCRIPTION
Fix typing error in example arg file