### PR TITLE
Do not require bundled args module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.argv[-1] == "publish":
     publish()
     sys.exit()
 
-required = ['args']
+required = ['']
 
 setup(
     name='clint',


### PR DESCRIPTION
Hi, the args module isn't used, it shouldn't be listed here.