### PR TITLE
Replace identity check with equality check

### DIFF
--- a/clint/textui/prompt.py
+++ b/clint/textui/prompt.py
@@ -66,7 +66,7 @@ def query(prompt, default='', validators=None, batch=False, mask_input=False):
         validators = [RegexValidator(r'.+')]
 
     # Let's build the prompt
-    if prompt[-1] is not ' ':
+    if prompt[-1] != ' ':
         prompt += ' '
 
     if default:


### PR DESCRIPTION
Due to the python 3.8 update, the compiler now raises a `SyntaxWarning` if it founds an identity check(`is`, `is not`) with a certain literal. This pr addresses that.