### PR TITLE
Change "is not" to "!=" to silence warning

### DIFF
--- a/clint/textui/prompt.py
+++ b/clint/textui/prompt.py
@@ -66,7 +66,7 @@ def query(prompt, default='', validators=None, batch=False, mask_input=False):
         validators = [RegexValidator(r'.+')]
 
     # Let's build the prompt
-    if prompt[-1] is not ' ':
+    if prompt[-1] != ' ':
         prompt += ' '
 
     if default:


### PR DESCRIPTION
Running this code gives the following warning:

```
/opt/homebrew/Cellar/gitless/0.8.8_7/libexec/lib/python3.9/site-packages/clint/textui/prompt.py:68: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if prompt[-1] is not ' ':
```