### PR TITLE
Python 3.8 SyntaxWarning fix

### DIFF
--- a/clint/textui/prompt.py
+++ b/clint/textui/prompt.py
@@ -66,7 +66,7 @@ def query(prompt, default='', validators=None, batch=False, mask_input=False):
         validators = [RegexValidator(r'.+')]
 
     # Let's build the prompt
-    if prompt[-1] is not ' ':
+    if prompt[-1] != ' ':
         prompt += ' '
 
     if default:


### PR DESCRIPTION
[Starting in Python 3.8](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior), this happened:
> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in bpo-34850.)

This patch takes the official advice and makes a tweak.